### PR TITLE
added updated_at & created_at fields to recovery struct

### DIFF
--- a/coordinator/graph/generated/generated.go
+++ b/coordinator/graph/generated/generated.go
@@ -43,7 +43,6 @@ type ResolverRoot interface {
 	Policy() PolicyResolver
 	Project() ProjectResolver
 	Query() QueryResolver
-	Recovery() RecoveryResolver
 	Suggestion() SuggestionResolver
 	User() UserResolver
 }
@@ -221,10 +220,6 @@ type QueryResolver interface {
 	Tokens(ctx context.Context, userID string) ([]string, error)
 	User(ctx context.Context, id string) (*models.User, error)
 	Users(ctx context.Context) ([]*models.User, error)
-}
-type RecoveryResolver interface {
-	CreatedAt(ctx context.Context, obj *models.Recovery) (*time.Time, error)
-	UpdatedAt(ctx context.Context, obj *models.Recovery) (*time.Time, error)
 }
 type SuggestionResolver interface {
 	Project(ctx context.Context, obj *models.Suggestion) (*models.Project, error)
@@ -4006,13 +4001,13 @@ func (ec *executionContext) _Recovery_created_at(ctx context.Context, field grap
 		Object:   "Recovery",
 		Field:    field,
 		Args:     nil,
-		IsMethod: true,
+		IsMethod: false,
 	}
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Recovery().CreatedAt(rctx, obj)
+		return obj.CreatedAt, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4024,9 +4019,9 @@ func (ec *executionContext) _Recovery_created_at(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*time.Time)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Recovery_updated_at(ctx context.Context, field graphql.CollectedField, obj *models.Recovery) (ret graphql.Marshaler) {
@@ -4040,13 +4035,13 @@ func (ec *executionContext) _Recovery_updated_at(ctx context.Context, field grap
 		Object:   "Recovery",
 		Field:    field,
 		Args:     nil,
-		IsMethod: true,
+		IsMethod: false,
 	}
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Recovery().UpdatedAt(rctx, obj)
+		return obj.UpdatedAt, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4058,9 +4053,9 @@ func (ec *executionContext) _Recovery_updated_at(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*time.Time)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Role_id(ctx context.Context, field graphql.CollectedField, obj *models.Role) (ret graphql.Marshaler) {
@@ -6650,36 +6645,18 @@ func (ec *executionContext) _Recovery(ctx context.Context, sel ast.SelectionSet,
 		case "id":
 			out.Values[i] = ec._Recovery_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
+				invalids++
 			}
 		case "created_at":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Recovery_created_at(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
+			out.Values[i] = ec._Recovery_created_at(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "updated_at":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Recovery_updated_at(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
+			out.Values[i] = ec._Recovery_updated_at(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7669,24 +7646,6 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 		}
 	}
 	return res
-}
-
-func (ec *executionContext) unmarshalNTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
-	return &res, err
-}
-
-func (ec *executionContext) marshalNTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec.marshalNTime2timeᚐTime(ctx, sel, *v)
 }
 
 func (ec *executionContext) marshalNToken2githubᚗcomᚋcapeprivacyᚋcapeᚋmodelsᚐToken(ctx context.Context, sel ast.SelectionSet, v models.Token) graphql.Marshaler {

--- a/coordinator/graph/recoveries.resolvers.go
+++ b/coordinator/graph/recoveries.resolvers.go
@@ -5,11 +5,7 @@ package graph
 
 import (
 	"context"
-	"fmt"
-	"time"
-
 	"github.com/capeprivacy/cape/coordinator/db"
-	"github.com/capeprivacy/cape/coordinator/graph/generated"
 	"github.com/capeprivacy/cape/coordinator/graph/model"
 	fw "github.com/capeprivacy/cape/framework"
 	"github.com/capeprivacy/cape/models"
@@ -116,16 +112,3 @@ func (r *mutationResolver) AttemptRecovery(ctx context.Context, input model.Atte
 	logger.Info().Msg("Successfully recovered account with a new password")
 	return nil, nil
 }
-
-func (r *recoveryResolver) CreatedAt(ctx context.Context, obj *models.Recovery) (*time.Time, error) {
-	panic(fmt.Errorf("not implemented"))
-}
-
-func (r *recoveryResolver) UpdatedAt(ctx context.Context, obj *models.Recovery) (*time.Time, error) {
-	panic(fmt.Errorf("not implemented"))
-}
-
-// Recovery returns generated.RecoveryResolver implementation.
-func (r *Resolver) Recovery() generated.RecoveryResolver { return &recoveryResolver{r} }
-
-type recoveryResolver struct{ *Resolver }

--- a/models/recovery.go
+++ b/models/recovery.go
@@ -14,6 +14,8 @@ type Recovery struct {
 	UserID      string       `json:"user_id"`
 	Credentials *Credentials `json:"-" gqlgen:"-"`
 	ExpiresAt   time.Time    `json:"expires_at"`
+	CreatedAt   time.Time    `json:"created_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
 }
 
 func (r *Recovery) Validate() error {
@@ -46,6 +48,8 @@ func NewRecovery(userID string, creds *Credentials) Recovery {
 		UserID:      userID,
 		Credentials: creds,
 		ExpiresAt:   time.Now().UTC().Add(RecoveryExpiration),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
 	}
 
 	return r


### PR DESCRIPTION
Forgotten in https://github.com/capeprivacy/cape/pull/369
These used to be on the type when it was a primitive, but
since it is just a struct now, they need to be explicitly declared.
